### PR TITLE
Fix undefined stats and report when running with multiple entry files

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,8 @@ module.exports.pitch = function(req) {
 		source.push("\t\tmocha.suite.suites.length = 0;");
 		source.push("\t\tvar stats = document.getElementById('mocha-stats');");
 		source.push("\t\tvar report = document.getElementById('mocha-report');");
-		source.push("\t\tstats.parentNode.removeChild(stats);");
-		source.push("\t\treport.parentNode.removeChild(report);");
+		source.push("\t\tstats && stats.parentNode.removeChild(stats);");
+		source.push("\t\treport && report.parentNode.removeChild(report);");
 		source.push("\t});");
 		source.push("}");
 	} else if(this.target == "node") {


### PR DESCRIPTION
I am adding all test files to my entry point like this:

	entry: {
		tests: Array.prototype.concat.apply([
			'webpack-hot-middleware/client?http://localhost:8001',
		], glob.sync('./test/**/*.spec.js')),
	},

Now module.hot.dispose is called for each of these files and after the first one has removed the stats and report nodes, all subsequent ones fail. This pull request simply checks whether the nodes exist before removing them.