### PR TITLE
Add support for mocha-phantomjs >= v4.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports.pitch = function(req) {
 	var source = [];
 	if(this.target == "web") {
 		source.push("require(" + JSON.stringify("!!" + path.join(__dirname, "web.js")) + ");");
+		source.push("if(typeof window !== 'undefined' && window.initMochaPhantomJS) { window.initMochaPhantomJS(); }");
 		source.push("mocha.setup(" + JSON.stringify(query["interface"] || "bdd") + ");");
 		source.push("require(" + JSON.stringify("!!" + req) + ")");
 		source.push("require(" + JSON.stringify("!!" + path.join(__dirname, "start.js")) + ");");


### PR DESCRIPTION
mocha-phantomjs requires that the initMochaPhantomJS function be called after Mocha is loaded (it depends on the `Mocha` object) and before `mocha.setup()` is called because it overwrites `mocha.ui`.