### PR TITLE
Permits all mocha setup options

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,12 +7,13 @@ var loaderUtils = require("loader-utils");
 module.exports = function() {};
 module.exports.pitch = function(req) {
 	this.cacheable && this.cacheable();
-	var query = loaderUtils.parseQuery(this.query);
 	var source = [];
+	var query = loaderUtils.parseQuery(this.query);
+	query.ui = query.ui || 'bdd';
 	if(this.target == "web") {
 		source.push("require(" + JSON.stringify("!!" + path.join(__dirname, "web.js")) + ");");
 		source.push("if(typeof window !== 'undefined' && window.initMochaPhantomJS) { window.initMochaPhantomJS(); }");
-		source.push("mocha.setup(" + JSON.stringify(query["interface"] || "bdd") + ");");
+		source.push("mocha.setup(" + JSON.stringify(query) + ");");
 		source.push("require(" + JSON.stringify("!!" + req) + ")");
 		source.push("require(" + JSON.stringify("!!" + path.join(__dirname, "start.js")) + ");");
 		source.push("if(module.hot) {");


### PR DESCRIPTION
It's not possible to configure all setup options with the actual version.
I just gave all the query to the mocha setup in order to have access to the following options :

```
- `ui` name "bdd", "tdd", "exports" etc
- `reporter` reporter instance, defaults to `mocha.reporters.spec`
- `globals` array of accepted globals
- `timeout` timeout in milliseconds
- `retries` number of times to retry failed tests
- `bail` bail on the first test failure
- `slow` milliseconds to wait before considering a test slow
- `ignoreLeaks` ignore global leaks
- `fullTrace` display the full stack-trace on failing
- `grep` string or regexp to filter tests with
```

Also I updated some dependencies versions.

Thanks for the reviews !