### PR TITLE
Upgrade all deps and allow mocha-3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
 		"url" : "https://github.com/webpack/mocha-loader"
 	},
 	"peerDependencies": {
-		"mocha": "^2.0.1"
+		"mocha": "^2.0.1 || ^3.0.0"
 	},
 	"dependencies": {
-		"script-loader": "~0.6.0",
-		"css-loader": "~0.9.0",
-		"style-loader": "~0.8.1",
-		"loader-utils": "~0.2.5"
+		"script-loader": "~0.7.0",
+		"css-loader": "~0.23.1",
+		"style-loader": "~0.13.1",
+		"loader-utils": "~0.2.15"
 	},
 	"licenses": [
 		{


### PR DESCRIPTION
mocha 3.0.0 was finally released yesterday.
I used this opportunity to upgrade deps as well.
Please consider merging and releasing a new official version of mocha-loader.

Thank you in advance.

Btw, I've tested it locally (in webpack-dev-server) and works as expected.