### PR TITLE
Update README to use -loader suffix to reflect webpack 2 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ module.exports = {
 #### entry-file.js
 ```js
 /*additional setup with other loaders (polyfills, ...)*/
-const context = require.context(/*directory*/'mocha!./tests', /*recursive*/true, /*match files*//_test.js$/);
+const context = require.context(/*directory*/'mocha-loader!./tests', /*recursive*/true, /*match files*//_test.js$/);
 context.keys().forEach(context);
 ```
 


### PR DESCRIPTION
Summary:
----

Webpack v2.1.0-beta.26 introduced a breaking change to require loaders to have the `-loader` suffix. 

This PR updates the README to show that pattern as an example instead of using the shorthand naming.

cc: @sokra @SpaceK33z 